### PR TITLE
Fix new repos set to public by default

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,9 +15,6 @@ repository:
   # A comma-separated list of topics to set on the repository
   #topics: github, probot
 
-  # Either `true` to make the repository private, or `false` to make it public.
-  private: false
-
   # Either `true` to enable issues for this repository, `false` to disable them.
   has_issues: true
 


### PR DESCRIPTION
1. This setting automatically sets new repositories in the organization to `public`.
2. It does not matter if the repo was explicitly set to `internal` or `private.` The bot changes the repo to `public`.
3. It can easily cause proprietary data to be exposed if the creator of the repo doesn't catch it in time before the first push.